### PR TITLE
webpack-plugin: when stats fail to upload, log error but continue build

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -29,7 +29,12 @@ class BundleAnalyzer {
         })
           .then(() => callback())
           .catch(error => {
-            callback(new Error(`Bundle Analyzer - ${error.message}`))
+            // eslint-disable-next-line no-console
+            console.error(`Bundle Analyzer - ${error.message}`)
+            // eslint-disable-next-line no-console
+            console.info(`Bundle Analyzer - Stats failed to upload. Continuing build...`)
+
+            callback()
           })
       },
     )


### PR DESCRIPTION
Fixes #11 

I've been seeing 503 errors a lot from Bundle Analyzer lately and this breaks all my CI builds.

If stats fail to upload, it isn't that important. We can just log the error and continue building.