### PR TITLE
chore(deps): bump axios version due to vulnerability

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "brotli-size": "^1.0.0",
     "cosmiconfig": "^5.2.1",
     "gzip-size": "^5.1.1",


### PR DESCRIPTION
Axios: Vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2020-28168